### PR TITLE
Move Graphback API generator to graphql.service

### DIFF
--- a/src/database/database.providers.ts
+++ b/src/database/database.providers.ts
@@ -1,11 +1,4 @@
 import { MongoClient } from 'mongodb';
-import {
-  createMongoDbProvider,
-  MongoDBDataProvider,
-} from '@graphback/runtime-mongo';
-import { buildGraphbackAPI } from 'graphback';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
 // Mongo Connection URL
 const url = 'mongodb://localhost:27017';
@@ -22,18 +15,7 @@ export const databaseProviders = [
       // Get db instance
       const db = client.db('todo');
 
-      // Create the MongoDB Data provider creator function
-      const dataProviderCreator = createMongoDbProvider(db);
-
-      // Import the data model
-      const userModel = readFileSync(
-        resolve(__dirname, '..', '..', 'model', 'datamodel.graphql'),
-        'utf8',
-      );
-
-      return buildGraphbackAPI(userModel, {
-        dataProviderCreator,
-      });
+      return db;
     },
   },
 ];


### PR DESCRIPTION
Moved the Graphback API generation code from database.providers to graphql.service.
Fixes #3